### PR TITLE
Nearest Neighbor Filtering, to sharpen pixels.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,50 +1,83 @@
+/*
+ * OpenComputers-3D-Designer - OpenComputers 3D printer scripts (.3dm) viewer/editor 
+ *
+ * Copyright (c) 2015 Kevin Velickovic
+ *
+ *
+ * Author(s):
+ *
+ *      Kevin Velickovic <k.velickovic@gmail.com>
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional Terms:
+ *
+ *      You are required to preserve legal notices and author attributions in
+ *      that material or in the Appropriate Legal Notices displayed by works
+ *      containing it.
+ */
 
 html, body {
-    margin: 0;
-    padding: 0;
+	padding:0;
+	margin:0;
 }
-#resourcepack {
-    border: 2px solid #8ac007;
-    padding: 1px 1px 3px;
-    z-index: 1;
+td#resourcepack {
+	z-index: 1;
+	border: 2px solid #8ac007;
+	padding: 1px;
+	padding-bottom: 3px;
+	margin-right:5px;
 }
 td#template {
-    border: 2px solid #8ac007;
-    padding: 1px;
-    z-index: 1;
+	z-index: 1;
+	border: 2px solid #8ac007;
+	padding: 1px;
 }
-td#resourcepack label {
-    display: block;
-    float: right;
-    padding-right: 10px;
-    white-space: nowrap;
+#resourcepack label {
+	display: block;
+	float: right;
+	padding-right: 10px;
+	white-space: nowrap;
 }
 #resourcepack input {
-    vertical-align: middle;
+	vertical-align: middle;
 }
 #resourcepack label span {
-    vertical-align: middle;
+	vertical-align: middle;
 }
 #resourcepack select {
-    border: medium none;
-    margin-bottom: 2px;
+	border: none;
+	margin-bottom: 2px;
 }
 div#editor {
-    border: 2px solid #8ac007;
-    height: 200px;
-    left: 5px;
-    margin-right: 70%;
-    position: absolute;
-    resize: both;
-    top: 40px;
-    width: 650px;
-    z-index: 1;
+resize: both;
+	position: absolute;
+	top: 40px;
+	left: 5px;
+	margin-right: 70%;
+	border: 2px solid #8AC007;
+	z-index: 1;
+	height:200px;
+	width: 650px;
 }
 div#canvas_container {
-    position: fixed;
+	position: fixed;
 }
-.lineHighlight {
-    background-color: #006600;
-    position: absolute;
-    z-index: 20;
+.lineHighlight{
+  position:absolute;
+  z-index:20;
+  background-color:#006600;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -1,88 +1,50 @@
-/*
- * OpenComputers-3D-Designer - OpenComputers 3D printer scripts (.3dm) viewer/editor 
- *
- * Copyright (c) 2015 Kevin Velickovic
- *
- *
- * Author(s):
- *
- *      Kevin Velickovic <k.velickovic@gmail.com>
- *
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *
- * Additional Terms:
- *
- *      You are required to preserve legal notices and author attributions in
- *      that material or in the Appropriate Legal Notices displayed by works
- *      containing it.
- */
 
 html, body {
-	padding:0;
-	margin:0;
+    margin: 0;
+    padding: 0;
 }
-div#resourcepack {
-	position: absolute;
-	z-index: 1;
-	left: 5px;
-	top: 5px;
-	border: 2px solid #8ac007;
-	padding: 1px;
-	padding-bottom: 3px;
+#resourcepack {
+    border: 2px solid #8ac007;
+    padding: 1px 1px 3px;
+    z-index: 1;
 }
-div#template {
-	position: absolute;
-	z-index: 1;
-	left: 332px;
-	top: 5px;
-	border: 2px solid #8ac007;
-	padding: 1px;
+td#template {
+    border: 2px solid #8ac007;
+    padding: 1px;
+    z-index: 1;
 }
-#resourcepack label {
-	display: block;
-	float: right;
-	padding-right: 10px;
-	white-space: nowrap;
+td#resourcepack label {
+    display: block;
+    float: right;
+    padding-right: 10px;
+    white-space: nowrap;
 }
 #resourcepack input {
-	vertical-align: middle;
+    vertical-align: middle;
 }
 #resourcepack label span {
-	vertical-align: middle;
+    vertical-align: middle;
 }
 #resourcepack select {
-	border: none;
-	margin-bottom: 2px;
+    border: medium none;
+    margin-bottom: 2px;
 }
 div#editor {
-resize: both;
-	position: absolute;
-	top: 40px;
-	left: 5px;
-	margin-right: 70%;
-	border: 2px solid #8AC007;
-	z-index: 1;
-	height:200px;
-	width: 650px;
+    border: 2px solid #8ac007;
+    height: 200px;
+    left: 5px;
+    margin-right: 70%;
+    position: absolute;
+    resize: both;
+    top: 40px;
+    width: 650px;
+    z-index: 1;
 }
 div#canvas_container {
-	position: fixed;
+    position: fixed;
 }
-.lineHighlight{
-  position:absolute;
-  z-index:20;
-  background-color:#006600;
+.lineHighlight {
+    background-color: #006600;
+    position: absolute;
+    z-index: 20;
 }

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
 		  <option value="Vanilla">Vanilla</option>
 		</select> 
 		<label for="alphaenabled"><input type="checkbox" id="alphaenabled" checked="true" /> <span>Alpha</span></label>
+		<label for="nearestfilterenabled"><input type="checkbox" id="nearestfilterenabled" checked="true" /> <span>Sharp Pixels</span></label>
 		</div>
 		<div id="template">
 		 <a>Template: </a><select>

--- a/index.html
+++ b/index.html
@@ -55,16 +55,17 @@
 		<script src="js/lib/ResizeSensor.js" type="text/javascript" charset="utf-8"></script>
 		<script src="js/lib/lua.vm.js" type="text/javascript" charset="utf-8"></script>
 		<script src="js/main.js" type="text/javascript" charset="utf-8"></script>
-		
-		<div id="resourcepack">
-		 <a>Resource pack: </a><select>
-		  <option value="Vanilla">Vanilla</option>
-		</select> 
-		<label for="alphaenabled"><input type="checkbox" id="alphaenabled" checked="true" /> <span>Alpha</span></label>
-		<label for="nearestfilterenabled"><input type="checkbox" id="nearestfilterenabled" checked="true" /> <span>Sharp Pixels</span></label>
-		</div>
-		<div id="template">
-		 <a>Template: </a><select>
+		<table>
+		 <tr>
+		  <td id="resourcepack">
+		   <a>Resource pack: </a><select>
+		    <option value="Vanilla">Vanilla</option>
+		   </select> 
+		   <label for="alphaenabled"><input type="checkbox" id="alphaenabled" checked="true" /> <span>Alpha</span></label>
+		   <label for="nearestfilterenabled"><input type="checkbox" id="nearestfilterenabled" checked="true" /> <span>Sharp Pixels</span></label>
+		  </td>
+		  <td id="template">
+		   <a>Template: </a><select>
 			<option selected disabled>Select...</option>
 			<option value="button.3dm">button.3dm</option>
 			<option value="cc.3dm">cc.3dm</option>
@@ -85,9 +86,11 @@
 			<option value="tree2.3dm">tree2.3dm</option>
 			<option value="villager.3dm">villager.3dm</option>
 			<option value="well.3dm">well.3dm</option>
-		</select> 
-		<button id="statetoggle" type="button">Toggle state</button> 
-		</div>
+		   </select> 
+		   <button id="statetoggle" type="button">Toggle state</button> 
+		  </td>
+		 </tr>
+		</table>
 		<div id="editor"></div>	
 		<div id="canvas_container">
 		</div>

--- a/js/main.js
+++ b/js/main.js
@@ -185,6 +185,10 @@ function buildGround()
 	var texture_side = THREE.ImageUtils.loadTexture( ( 'img/resourcepacks/' + resourcepack + '/blocks/grass_side.png' ) );
 	var texture_top  = THREE.ImageUtils.loadTexture( ( 'img/resourcepacks/' + resourcepack + '/blocks/grass_top.png' ) );
 	var texture_bot  = THREE.ImageUtils.loadTexture( ( 'img/resourcepacks/' + resourcepack + '/blocks/dirt.png' ) );
+	if(resourcepack_nearestfilter)
+		texture_side.magFilter = THREE.NearestFilter;
+		texture_top.magFilter = THREE.NearestFilter;
+		texture_bot.magFilter = THREE.NearestFilter;
 	
 	texture_side.wrapS = THREE.RepeatWrapping;
 	texture_side.wrapT = THREE.RepeatWrapping;

--- a/js/main.js
+++ b/js/main.js
@@ -34,6 +34,7 @@ var JLua = null;
 var camera, scene, renderer;
 var resourcepack = 'Vanilla';
 var resourcepack_alpha = true;
+var resourcepack_nearestfilter = true;
 var current_state = false;
 var editor = null;
 var ground_mesh = null;
@@ -111,6 +112,7 @@ $( document ).ready(function() {
 	
 	var resourcepack_select = $("#resourcepack select");
 	var alpha_checkbox = $("#resourcepack #alphaenabled");
+	var nearestfilter_checkbox = $("#resourcepack #nearestfilterenabled");
 	var template_select = $("#template select");
 	
 	resourcepack_select.prop('selectedIndex',0);
@@ -138,6 +140,13 @@ $( document ).ready(function() {
 		resourcepack_alpha = alpha_checkbox.prop('checked');
 		
 		renderer.sortObjects = !resourcepack_alpha;
+		
+		change_event( editor.getValue() );
+	});
+	
+	
+	nearestfilter_checkbox.on('change', function() {
+		resourcepack_nearestfilter = nearestfilter_checkbox.prop('checked');
 		
 		change_event( editor.getValue() );
 	});
@@ -230,7 +239,8 @@ function create_part( i_pos_1, i_pos_2, i_pos_3, i_size_1, i_size_2, i_size_3, t
 	for(i = 0; i < 6; i++)
 	{
 		loaded_textures.push( THREE.ImageUtils.loadTexture(texture_path) );
-		loaded_textures[ i ].magFilter = THREE.NearestFilter;
+		if(resourcepack_nearestfilter)
+			loaded_textures[ i ].magFilter = THREE.NearestFilter;
 		loaded_textures[ i ].anisotropy = 0;
 	}
 	

--- a/js/main.js
+++ b/js/main.js
@@ -230,6 +230,7 @@ function create_part( i_pos_1, i_pos_2, i_pos_3, i_size_1, i_size_2, i_size_3, t
 	for(i = 0; i < 6; i++)
 	{
 		loaded_textures.push( THREE.ImageUtils.loadTexture(texture_path) );
+		loaded_textures[ i ].magFilter = THREE.NearestFilter;
 		loaded_textures[ i ].anisotropy = 0;
 	}
 	


### PR DESCRIPTION
### Added a checkbox next to Alpha that enables nearest neighbor, sharpening all the pixels.

(Its labelled "Sharp Pixels", and is enabled by default)
The nearest neighbor is just using THREE's filters:
`whatevertexture.magFilter=THREE.NearestFilter`
### I Also changed #resourcepacks and #templates to elements in a table rather than absolutely positioned divs, because tables make the positioning automatic.

(You can move around the elements using margins and paddings though, if you really liked that gap you had before.)
